### PR TITLE
Add `Image` "initial" language for simpler creation of images

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ lazy val commonSettings = Seq(
 
   initialCommands in console := """
       |import doodle.java2d._
+      |import doodle.image._
       |import doodle.syntax._
       |import doodle.examples._
     """.trim.stripMargin,
@@ -54,6 +55,7 @@ lazy val root = (project in file("."))
     initialCommands in console := """
       |import cats.instances.all._
       |import doodle.java2d._
+      |import doodle.image._
       |import doodle.syntax._
       |import doodle.engine.Writer._
       |import doodle.examples._

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,7 @@ lazy val root = (project in file("."))
     """.trim.stripMargin
   )
   .dependsOn(animate, core, explore)
+  .aggregate(animate, core, explore)
 
 lazy val core = (project in file("core"))
   .settings(commonSettings)

--- a/core/src/main/scala/doodle/algebra/Shape.scala
+++ b/core/src/main/scala/doodle/algebra/Shape.scala
@@ -17,11 +17,18 @@
 package doodle
 package algebra
 
-/** Higher level shape primitives */
+/** Higher level shape primitives. These draw common geometric shapes with the
+  * center of the shape the origin of the bounding box. */
 trait Shape[F[_]] {
+  /** A rectangle with the given width and height. */
   def rectangle(width: Double, height: Double): F[Unit]
+  /** A square with the given side length. */
   def square(width: Double): F[Unit]
+  /** An isoceles triangle with the given width and height. */
   def triangle(width: Double, height: Double): F[Unit]
-  def circle(radius: Double): F[Unit]
+  /** A circle with the given diameter. We use diamter rather than radius so
+    * circle(100) has the same size as square(100) */
+  def circle(diameter: Double): F[Unit]
+  /** The empty shape, which is no shape at all. */
   def empty: F[Unit]
 }

--- a/core/src/main/scala/doodle/algebra/generic/BoundingBox.scala
+++ b/core/src/main/scala/doodle/algebra/generic/BoundingBox.scala
@@ -65,8 +65,8 @@ final case class BoundingBox(left: Double,
 object BoundingBox {
   val empty = BoundingBox(0,0,0,0)
 
-  /** Create a [[doodle.algebra.generic.BoundingBox]] with the given width and heigh and
-    * the origin centered within the box. */
+  /** Create a [[doodle.algebra.generic.BoundingBox]] with the given width and
+    * height and the origin centered within the box. */
   def centered(width: Double, height: Double): BoundingBox = {
     val w = width / 2.0
     val h = height / 2.0

--- a/core/src/main/scala/doodle/algebra/generic/GenericShape.scala
+++ b/core/src/main/scala/doodle/algebra/generic/GenericShape.scala
@@ -63,18 +63,17 @@ trait GenericShape[G] extends Shape[Finalized[G,?]] {
        })
     }
 
-  def circle(radius: Double): Finalized[G,Unit] =
+  def circle(diameter: Double): Finalized[G,Unit] =
     Finalized{ dc =>
       val strokeWidth = dc.strokeWidth.getOrElse(0.0)
-      val diameter = radius * 2.0
       val bb = BoundingBox.centered(strokeWidth + diameter, strokeWidth + diameter)
       (bb,
        Contextualized{ (gc, tx) =>
          Renderable { origin =>
            val o = tx(origin)
            IO {
-             graphicsContext.fillCircle(gc)(dc, o, radius)
-             graphicsContext.strokeCircle(gc)(dc, o, radius)
+             graphicsContext.fillCircle(gc)(dc, o, diameter / 2.0)
+             graphicsContext.strokeCircle(gc)(dc, o, diameter / 2.0)
            }
          }
        })

--- a/core/src/main/scala/doodle/core/PathElement.scala
+++ b/core/src/main/scala/doodle/core/PathElement.scala
@@ -70,19 +70,19 @@ object PathElement {
 
 
   /** Utility to construct a `List[PathElement]` that represents a circle. */
-  def circle(center: Point, radius: Double): List[PathElement] =
-    circle(center.x, center.y, radius)
+  def circle(center: Point, diameter: Double): List[PathElement] =
+    circle(center.x, center.y, diameter)
 
   /** Utility to construct a `List[PathElement]` that represents a circle. */
-  def circle(x: Double, y: Double, radius: Double): List[PathElement] = {
+  def circle(x: Double, y: Double, diameter: Double): List[PathElement] = {
     import Point.cartesian
     // See http://spencermortensen.com/articles/bezier-circle/ for approximation
     // of a circle with a Bezier curve.
-    val r = radius
+    val r = diameter / 2.0
     val c = 0.551915024494
     val cR = c * r
     List(
-      MoveTo(cartesian(x, y + radius)),
+      MoveTo(cartesian(x, y + r)),
       BezierCurveTo(cartesian(x + cR,  y + r),   cartesian(x + r,   y + cR),  cartesian(x + r,  y)),
       BezierCurveTo(cartesian(x + r,   y + -cR), cartesian(x + cR,  y + -r),  cartesian(x,      y + -r)),
       BezierCurveTo(cartesian(x + -cR, y + -r),  cartesian(x + -r,  y + -cR), cartesian(x + -r, y)),

--- a/core/src/main/scala/doodle/image/Image.scala
+++ b/core/src/main/scala/doodle/image/Image.scala
@@ -1,0 +1,375 @@
+package doodle
+package image
+
+import doodle.core._
+import doodle.language.Basic
+
+sealed abstract class Image extends Product with Serializable {
+  import Image.Elements._
+
+  // Layout ----------------------------------------------------------
+
+  def beside(right: Image): Image =
+    Beside(this, right)
+
+  def on(bottom: Image): Image =
+    On(this, bottom)
+
+  def under(top: Image): Image =
+    On(top, this)
+
+  def above(bottom: Image): Image =
+    Above(this, bottom)
+
+  def below(top: Image): Image =
+    Above(top, this)
+
+
+  // Context Transform ------------------------------------------------
+
+  def strokeColor(color: Color): Image =
+    StrokeColor(this, color)
+
+  // def strokeColorTransform(f: Color => Color): Image =
+  //   ContextTransform(_.strokeColorTransform(f), this)
+
+  def strokeWidth(width: Double): Image =
+    StrokeWidth(this, width)
+
+  def fillColor(color: Color): Image =
+    FillColor(this, color)
+
+  // def fillColorTransform(f: Color => Color): Image =
+  //   ContextTransform(_.fillColorTransform(f), this)
+
+  // def fillGradient(gradient: Gradient): Image =
+  //   ContextTransform(_.fillGradient(gradient), this)
+
+  // def fillGradientTransform(f: Gradient => Gradient): Image =
+  //   ContextTransform(_.fillGradientTransform(f), this)
+
+  def noStroke: Image =
+    NoStroke(this)
+
+  def noFill: Image =
+    NoFill(this)
+
+  // def font(font: Font): Image =
+  //   ContextTransform(_.font(font), this)
+
+
+  // Affine Transform -------------------------------------------------
+
+  // def transform(tx: core.transform.Transform): Image =
+  //   Transform(tx, this)
+
+  // def rotate(angle: Angle): Image =
+  //   this.transform(core.transform.Transform.rotate(angle))
+
+  def at(vec: Vec): Image =
+    // Transform(core.transform.Transform.translate(vec.x, vec.y), this)
+    At(this, vec.x, vec.y)
+
+  def at(x: Double, y: Double): Image =
+    // Transform(core.transform.Transform.translate(x, y), this)
+    At(this, x, y)
+
+  // Convert to tagless final format
+
+  def compile[Algebra[A[?]] <: Basic[A[?]],F[_]]: doodle.algebra.Image[Algebra[F],F,Unit] =
+    Image.compile(this)
+}
+sealed abstract class Path extends Image {
+  import Image.Elements._
+
+  def isOpen: Boolean =
+    this match {
+      case OpenPath(_)   => true
+      case ClosedPath(_) => false
+    }
+
+  def isClosed: Boolean =
+    !this.isOpen
+
+  def open: Path =
+    this match {
+      case OpenPath(_)      => this
+      case ClosedPath(elts) => OpenPath(elts)
+    }
+
+  def close: Path =
+    this match {
+      case OpenPath(elts) => ClosedPath(elts)
+      case ClosedPath(_)  => this
+    }
+}
+object Image {
+  /** Contains the leaves of the Image algebraic data type. Packaged here so they
+    * don't pollute the namespace when importing Image to access to the smart
+    * constructors. */
+  object Elements {
+    final case class OpenPath(elements: List[PathElement]) extends Path
+    final case class ClosedPath(elements: List[PathElement]) extends Path
+    // final case class Text(get: String) extends Image
+    final case class Circle(r: Double) extends Image
+    final case class Rectangle(w: Double, h: Double) extends Image
+    final case class Triangle(w: Double, h: Double) extends Image
+    // final case class Draw(w: Double, h: Double, f: Canvas => Unit) extends Image
+    final case class Beside(l: Image, r: Image) extends Image
+    final case class Above(l: Image, r: Image) extends Image
+    final case class On(t: Image, b: Image) extends Image
+    final case class At(image: Image, x: Double, y: Double) extends Image
+    // final case class Transform(tx: transform.Transform, i: Image) extends Image
+    // Style
+    final case class StrokeWidth(image: Image, width: Double) extends Image
+    final case class StrokeColor(image: Image, color: Color) extends Image
+    final case class FillColor(image: Image, color: Color) extends Image
+    final case class NoStroke(image: Image) extends Image
+    final case class NoFill(image: Image) extends Image
+
+    final case object Empty extends Image
+  }
+  import Elements._
+
+  // Smart constructors
+
+  def closedPath(elements: Seq[PathElement]): Path = {
+    // Paths must start at the origin. Thus we always move to the origin to
+    // start.
+    ClosedPath((PathElement.moveTo(0,0) +: elements).toList)
+  }
+
+
+  def openPath(elements: Seq[PathElement]): Path = {
+    // Paths must start at the origin. Thus we always move to the origin to
+    // start.
+    OpenPath((PathElement.moveTo(0,0) +: elements).toList)
+  }
+
+  // def text(characters: String): Image =
+  //   Text(characters)
+
+  def line(x: Double, y: Double): Image = {
+    val startX = -x/2
+    val startY = -y/2
+    val endX = x/2
+    val endY = y/2
+    openPath(
+      List(
+        PathElement.moveTo(startX, startY),
+        PathElement.lineTo(endX, endY)
+      )
+    )
+  }
+
+  def circle(r: Double): Image =
+    Circle(r)
+
+  def rectangle(w: Double, h: Double): Image =
+    Rectangle(w,h)
+
+  def square(side: Double): Image =
+    rectangle(side, side)
+
+  def regularPolygon(sides: Int, radius: Double, angle: Angle): Image = {
+    import PathElement._
+
+    val rotation = Angle.one / sides.toDouble
+    val path =
+      (1 to sides).map { n =>
+          lineTo(radius, rotation * n.toDouble + angle)
+      }.toList
+
+    closedPath(moveTo(radius, angle) +: path)
+  }
+
+  def star(points: Int, outerRadius: Double, innerRadius: Double, angle: Angle): Image = {
+    import PathElement._
+
+    val rotation = Angle.one / (points * 2.0)
+    val path =
+      (1 to (points * 2)).map { n =>
+        if(n % 2 == 0)
+          lineTo(outerRadius, rotation * n.toDouble + angle)
+        else
+          lineTo(innerRadius, rotation * n.toDouble + angle)
+      }.toList
+
+    closedPath(moveTo(outerRadius, angle) +: path)
+  }
+
+  def rightArrow(w: Double, h: Double): Image = {
+    import PathElement._
+
+    val path = List(
+      moveTo(w/2, 0),
+      lineTo(0, h/2),
+
+      lineTo(0, h * 0.2),
+      lineTo(-w/2, h * 0.2),
+      lineTo(-w/2, -h * 0.2),
+      lineTo(0, -h * 0.2),
+
+      lineTo(0, -h/2),
+      lineTo(w/2, 0)
+    )
+
+    closedPath(path)
+  }
+
+  def roundedRectangle(w: Double, h: Double, r: Double): Image = {
+    import PathElement._
+
+    // Clamp radius to the smallest of width and height
+    val radius =
+      if(r > w/2 || r > h/2)
+        (w/2) min (h/2)
+      else
+        r
+
+    // Magic number of drawing circles with bezier curves
+    // See http://spencermortensen.com/articles/bezier-circle/ for approximation
+    // of a circle with a Bezier curve.
+    val c = (4.0/3.0) * (Math.sqrt(2) - 1)
+    val cR = c * radius
+
+    val elts = List(
+      moveTo(w/2 - radius, h/2),
+      curveTo(w/2 - radius + cR, h/2,
+              w/2, h/2 - radius + cR,
+              w/2, h/2 - radius),
+      lineTo(w/2, -h/2 + radius),
+      curveTo(w/2, -h/2 + radius - cR,
+              w/2 - radius + cR, -h/2,
+              w/2 - radius, -h/2),
+      lineTo(-w/2 + radius, -h/2),
+      curveTo(-w/2 + radius - cR, -h/2,
+              -w/2, -h/2 + radius - cR,
+              -w/2, -h/2 + radius),
+      lineTo(-w/2, h/2 - radius),
+      curveTo(-w/2, h/2 - radius + cR,
+              -w/2 + radius - cR, h/2,
+              -w/2 + radius, h/2),
+      lineTo(w/2 - radius, h/2)
+    )
+
+    closedPath(elts)
+  }
+
+  def triangle(w: Double, h: Double): Image =
+    Triangle(w,h)
+
+  /**
+    * Construct an open path of bezier curves that intersects all the given
+    * points. Defaults to `catmulRom` with the default tension.
+    */
+  def interpolatingSpline(points: Seq[Point]): Path =
+    catmulRom(points)
+
+  /**
+    * Interpolate a spline (a curve) that passes through all the given points,
+    * using the Catmul Rom formulation (see, e.g., https://en.wikipedia.org/wiki/Cubic_Hermite_spline)
+    *
+    * The tension can be changed to control how tightly the curve turns. It defaults to 0.5.
+    *
+    * The Catmul Rom algorithm requires a point before and after each pair of
+    * points that define the curve. To meet this condition for the first and last
+    * points in `points`, they are repeated.
+    *
+    * If `points` has less than two elements an empty `Path` is returned.
+    */
+  def catmulRom(points: Seq[Point], tension: Double = 0.5): Path = {
+    /*
+    To convert Catmul Rom curve to a Bezier curve, multiply points by (invB * catmul)
+
+    See, for example, http://www.almightybuserror.com/2009/12/04/drawing-splines-in-opengl.html
+
+    Inverse Bezier matrix
+    val invB = Array[Double](0, 0,       0,       1,
+                             0, 0,       1.0/3.0, 1,
+                             0, 1.0/3.0, 2.0/3.0, 1,
+                             1, 1,       1,       1)
+
+    Catmul matrix with given tension
+    val catmul = Array[Double](-tension,    2 - tension,  tension - 2,       tension,
+                               2 * tension, tension - 3,  3 - (2 * tension), -tension,
+                               -tension,    0,            tension,           0,
+                               0,           1,            0,                 0)
+
+    invB * catmul
+    val matrix = Array[Double](0,            1,           0,           0,
+                               -tension/3.0, 1,           tension/3.0, 0,
+                               0,            tension/3.0, 1,           -tension/3.0,
+                               0,            0,           1,           0)
+     */
+    def toCurve(pt0: Point, pt1: Point, pt2: Point, pt3: Point): PathElement =
+      PathElement.curveTo(
+        ((-tension * pt0.x) + 3*pt1.x + (tension * pt2.x)) / 3.0,
+        ((-tension * pt0.y) + 3*pt1.y + (tension * pt2.y)) / 3.0,
+
+        ((tension * pt1.x) + 3*pt2.x - (tension * pt3.x)) / 3.0,
+        ((tension * pt1.y) + 3*pt2.y - (tension * pt3.y)) / 3.0,
+
+        pt2.x,
+        pt2.y
+      )
+
+
+    def iter(points: List[Point]): List[PathElement] = {
+      points match {
+        case pt0 :: pt1 :: pt2 :: pt3 :: pts =>
+          toCurve(pt0, pt1, pt2, pt3) +: iter(pt1 +: pt2 +: pt3 +: pts)
+
+        case pt0 :: pt1 :: pt2 :: Seq() =>
+          // Case where we've reached the end of the sequence of points
+          // We repeat the last point
+          val pt3 = pt2
+          List(toCurve(pt0, pt1, pt2, pt3))
+
+        case _ =>
+          // There were two or fewer points in the sequence
+          List.empty[PathElement]
+      }
+    }
+
+    points.headOption.fold(OpenPath(List.empty)){ pt0 =>
+      OpenPath(PathElement.moveTo(pt0) :: iter(pt0 :: points.toList))
+    }
+  }
+
+//  def draw(width: Double, height: Double)(f: Canvas => Unit): Image =
+//    Draw(width, height, f)
+
+  def empty: Image =
+    Empty
+
+  /** Compile an `Image` to a `doodle.algebra.Image` */
+  def compile[Algebra[A[?]] <: Basic[A[?]],F[_]](image: Image): doodle.algebra.Image[Algebra[F],F,Unit] = {
+    import cats.instances.unit._
+    import Elements._
+
+    doodle.algebra.Image[Algebra[F],F,Unit]{ algebra =>
+      image match {
+        case OpenPath(elements) => algebra.path(doodle.core.OpenPath(elements.reverse))
+        case ClosedPath(elements) => algebra.path(doodle.core.ClosedPath(elements.reverse))
+
+        case Circle(r) => algebra.circle(r)
+        case Rectangle(w, h) => algebra.rectangle(w, h)
+        case Triangle(w, h) => algebra.triangle(w, h)
+
+        case Beside(l, r) => algebra.beside(compile(l)(algebra), compile(r)(algebra))
+        case Above(l, r) => algebra.above(compile(l)(algebra), compile(r)(algebra))
+        case On(t, b) => algebra.on(compile(t)(algebra), compile(b)(algebra))
+        case At(image, x, y) => algebra.at(compile(image)(algebra), x, y)
+
+        case StrokeWidth(image, width) => algebra.strokeWidth(compile(image)(algebra), width)
+        case StrokeColor(image, color) => algebra.strokeColor(compile(image)(algebra), color)
+        case FillColor(image, color) => algebra.fillColor(compile(image)(algebra), color)
+        case NoStroke(image) => algebra.noStroke(compile(image)(algebra))
+        case NoFill(image) => algebra.noFill(compile(image)(algebra))
+
+        case Empty => algebra.empty
+      }
+    }
+  }
+}

--- a/core/src/main/scala/doodle/image/Image.scala
+++ b/core/src/main/scala/doodle/image/Image.scala
@@ -111,7 +111,7 @@ object Image {
     final case class OpenPath(elements: List[PathElement]) extends Path
     final case class ClosedPath(elements: List[PathElement]) extends Path
     // final case class Text(get: String) extends Image
-    final case class Circle(r: Double) extends Image
+    final case class Circle(d: Double) extends Image
     final case class Rectangle(w: Double, h: Double) extends Image
     final case class Triangle(w: Double, h: Double) extends Image
     // final case class Draw(w: Double, h: Double, f: Canvas => Unit) extends Image
@@ -162,8 +162,8 @@ object Image {
     )
   }
 
-  def circle(r: Double): Image =
-    Circle(r)
+  def circle(d: Double): Image =
+    Circle(d)
 
   def rectangle(w: Double, h: Double): Image =
     Rectangle(w,h)
@@ -227,7 +227,7 @@ object Image {
       else
         r
 
-    // Magic number of drawing circles with bezier curves
+    // Magic number for drawing circles with bezier curves
     // See http://spencermortensen.com/articles/bezier-circle/ for approximation
     // of a circle with a Bezier curve.
     val c = (4.0/3.0) * (Math.sqrt(2) - 1)
@@ -350,25 +350,40 @@ object Image {
 
     doodle.algebra.Image[Algebra[F],F,Unit]{ algebra =>
       image match {
-        case OpenPath(elements) => algebra.path(doodle.core.OpenPath(elements.reverse))
-        case ClosedPath(elements) => algebra.path(doodle.core.ClosedPath(elements.reverse))
+        case OpenPath(elements) =>
+          algebra.path(doodle.core.OpenPath(elements.reverse))
+        case ClosedPath(elements) =>
+          algebra.path(doodle.core.ClosedPath(elements.reverse))
 
-        case Circle(r) => algebra.circle(r)
-        case Rectangle(w, h) => algebra.rectangle(w, h)
-        case Triangle(w, h) => algebra.triangle(w, h)
+        case Circle(d) =>
+          algebra.circle(d)
+        case Rectangle(w, h) =>
+          algebra.rectangle(w, h)
+        case Triangle(w, h) =>
+          algebra.triangle(w, h)
 
-        case Beside(l, r) => algebra.beside(compile(l)(algebra), compile(r)(algebra))
-        case Above(l, r) => algebra.above(compile(l)(algebra), compile(r)(algebra))
-        case On(t, b) => algebra.on(compile(t)(algebra), compile(b)(algebra))
-        case At(image, x, y) => algebra.at(compile(image)(algebra), x, y)
+        case Beside(l, r) =>
+          algebra.beside(compile(l)(algebra), compile(r)(algebra))
+        case Above(l, r) =>
+          algebra.above(compile(l)(algebra), compile(r)(algebra))
+        case On(t, b) =>
+          algebra.on(compile(t)(algebra), compile(b)(algebra))
+        case At(image, x, y) =>
+          algebra.at(compile(image)(algebra), x, y)
 
-        case StrokeWidth(image, width) => algebra.strokeWidth(compile(image)(algebra), width)
-        case StrokeColor(image, color) => algebra.strokeColor(compile(image)(algebra), color)
-        case FillColor(image, color) => algebra.fillColor(compile(image)(algebra), color)
-        case NoStroke(image) => algebra.noStroke(compile(image)(algebra))
-        case NoFill(image) => algebra.noFill(compile(image)(algebra))
+        case StrokeWidth(image, width) =>
+          algebra.strokeWidth(compile(image)(algebra), width)
+        case StrokeColor(image, color) =>
+          algebra.strokeColor(compile(image)(algebra), color)
+        case FillColor(image, color) =>
+          algebra.fillColor(compile(image)(algebra), color)
+        case NoStroke(image) =>
+          algebra.noStroke(compile(image)(algebra))
+        case NoFill(image) =>
+          algebra.noFill(compile(image)(algebra))
 
-        case Empty => algebra.empty
+        case Empty =>
+          algebra.empty
       }
     }
   }

--- a/core/src/main/scala/doodle/java2d/algebra/Graphics2DGraphicsContext.scala
+++ b/core/src/main/scala/doodle/java2d/algebra/Graphics2DGraphicsContext.scala
@@ -45,14 +45,16 @@ object Graphics2DGraphicsContext extends GraphicsContext[Graphics2D] {
     dc.fill.foreach{ f =>
       Java2D.setFill(gc, f)
       val r = radius.toInt
-      gc.fillOval(center.x.toInt - r, center.y.toInt - r, r, r)
+      val d = (radius * 2).toInt
+      gc.fillOval(center.x.toInt - r, center.y.toInt - r, d, d)
     }
   }
   def strokeCircle(gc: Graphics2D)(dc: DrawingContext, center: Point, radius: Double): Unit = {
     dc.stroke.foreach{ s =>
       Java2D.setStroke(gc, s)
       val r = radius.toInt
-      gc.drawOval(center.x.toInt - r, center.y.toInt - r, r, r)
+      val d = (radius * 2).toInt
+      gc.drawOval(center.x.toInt - r, center.y.toInt - r, d, d)
     }
   }
 

--- a/core/src/main/scala/doodle/syntax/ImageSyntax.scala
+++ b/core/src/main/scala/doodle/syntax/ImageSyntax.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 noelwelsh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package syntax
+
+import doodle.engine.{Engine,Frame}
+import doodle.image.Image
+import doodle.language.Basic
+
+trait ImageSyntax {
+  implicit class ImageOps(image: Image) {
+    def draw[Algebra[A[?]] <: Basic[A[?]],F[_],C](implicit engine: Engine[Algebra[F], F, C]): Unit =
+    (for {
+       canvas <- engine.frame(Frame.fitToImage())
+       a      <- engine.render(canvas)(algebra => image.compile(algebra))
+     } yield a).unsafeRunSync()
+  }
+}

--- a/core/src/main/scala/doodle/syntax/package.scala
+++ b/core/src/main/scala/doodle/syntax/package.scala
@@ -20,6 +20,7 @@ package object syntax
     extends AngleSyntax
     with BlendSyntax
     with EngineSyntax
+    with ImageSyntax
     with LayoutSyntax
     with NormalizedSyntax
     with PathSyntax
@@ -30,6 +31,7 @@ package object syntax
   object angle extends AngleSyntax
   object blend extends BlendSyntax
   object engine extends EngineSyntax
+  object image extends ImageSyntax
   object layout extends LayoutSyntax
   object normalized extends NormalizedSyntax
   object path extends PathSyntax

--- a/core/src/test/scala/doodle/algebra/generic/Reify.scala
+++ b/core/src/test/scala/doodle/algebra/generic/Reify.scala
@@ -37,11 +37,11 @@ object Reify {
         extends GraphicsContext
     final case class FillCircle(dc: DrawingContext,
                                 center: Point,
-                                radius: Double)
+                                diameter: Double)
         extends GraphicsContext
     final case class StrokeCircle(dc: DrawingContext,
                                   center: Point,
-                                  radius: Double)
+                                  diameter: Double)
         extends GraphicsContext
     final case class FillPolygon(dc: DrawingContext, points: Array[Point])
         extends GraphicsContext
@@ -77,12 +77,12 @@ object Reify {
 
     def fillCircle(dc: DrawingContext,
                    center: Point,
-                   radius: Double): GraphicsContext =
-      FillCircle(dc, center, radius)
+                   diameter: Double): GraphicsContext =
+      FillCircle(dc, center, diameter)
     def strokeCircle(dc: DrawingContext,
                      center: Point,
-                     radius: Double): GraphicsContext =
-      StrokeCircle(dc, center, radius)
+                     diameter: Double): GraphicsContext =
+      StrokeCircle(dc, center, diameter)
 
     def fillPolygon(dc: DrawingContext, points: Array[Point]): GraphicsContext =
       FillPolygon(dc, points)

--- a/core/src/test/scala/doodle/algebra/generic/TestGraphicsContext.scala
+++ b/core/src/test/scala/doodle/algebra/generic/TestGraphicsContext.scala
@@ -45,11 +45,11 @@ object TestGraphicsContext {
       gc.add(Reify.GraphicsContext.strokeRect(dc, center, width, height))
 
     def fillCircle(
-        gc: Log)(dc: DrawingContext, center: Point, radius: Double): Unit =
-      gc.add(Reify.GraphicsContext.fillCircle(dc, center, radius))
+        gc: Log)(dc: DrawingContext, center: Point, diameter: Double): Unit =
+      gc.add(Reify.GraphicsContext.fillCircle(dc, center, diameter))
     def strokeCircle(
-        gc: Log)(dc: DrawingContext, center: Point, radius: Double): Unit =
-      gc.add(Reify.GraphicsContext.strokeCircle(dc, center, radius))
+        gc: Log)(dc: DrawingContext, center: Point, diameter: Double): Unit =
+      gc.add(Reify.GraphicsContext.strokeCircle(dc, center, diameter))
 
     def fillPolygon(gc: Log)(dc: DrawingContext, points: Array[Point]): Unit =
       gc.add(Reify.GraphicsContext.fillPolygon(dc, points))


### PR DESCRIPTION
The `Image` language matches the same abstraction in earlier versions of Doodle (apart from the features that are currently unimplemented). It's much easier to work with than the tagless final algebras as the amount of mucking around with types is much reduced. However it's not extensible, unlike the tagless final representation. It compiles into tagless final, which can then be rendered in the usual way.